### PR TITLE
Correct script file name in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ Login into your clean server, clone git repository and run the installer,
 ```
 git clone https://github.com/switnet-ltd/quick-jibri-installer
 cd quick-jibri-installer
-bash quick-jibri-installer.sh
+sudo bash quick_jibri_installer.sh
 ```
 
 ### Add Jibri node


### PR DESCRIPTION
The README suggests running a script called `quick-jibri-installer.sh`, but it doesn't exist. What exists is `quick_jibri_installer.sh`. I've also added `sudo` since it asks for root permissions.