### PR TITLE
5.4.0

### DIFF
--- a/jitsi-updater.sh
+++ b/jitsi-updater.sh
@@ -44,8 +44,8 @@ fi
 if [ -z $CHDB ]; then
 	echo "Seems no chromedriver installed"
 else
-    CHD_AVB="$($CHDB -v | awk '{print $2}')"
-    CHD_AVB_2D="$(echo $CHD_AVB|cut -d "." -f 1,2)"
+    CHD_VER_LOCAL="$($CHDB -v | awk '{print $2}')"
+    CHD_VER_2D="$(echo $CHD_VER_LOCAL|cut -d "." -f 1,2)"
 fi
 
 # True if $1 is greater than $2
@@ -90,16 +90,17 @@ upgrade_cd() {
 if [ ! -z $GOOGL_VER_2D ]; then
     if version_gt "$GOOGL_VER_2D" "$CHD_VER_2D" && \
     [ "$GOOGL_VER_2D" = "$CHD_LTST_2D" ]; then
-    then
         echo "Upgrading Chromedriver to Google Chromes version"
-        wget https://chromedriver.storage.googleapis.com/$CHD_LTST/chromedriver_linux64.zip
-        unzip chromedriver_linux64.zip
-        sudo cp chromedriver $CHDB
-        rm -rf chromedriver chromedriver_linux64.zip
+        wget -q https://chromedriver.storage.googleapis.com/$CHD_LTST/chromedriver_linux64.zip \
+             -O /tmp/chromedriver_linux64.zip
+        unzip /tmp/chromedriver_linux64.zip -d /usr/local/bin/
+        chown root:root $CHDB
+        chmod 0755 $CHDB
+        rm -rf /tpm/chromedriver_linux64.zip
         chromedriver -v
     else
         echo "No need to upgrade Chromedriver"
-        printf "Current version: ${Green} $CHD_AVB_2D ${Color_Off}\n"
+        printf "Current version: ${Green} $CHD_VER_2D ${Color_Off}\n"
     fi
 else
   printf "${Yellow} -> No Google Chrome versión to match, leaving untouched.${Color_Off}\n"
@@ -109,7 +110,7 @@ fi
 check_lst_cd() {
 printf "${Purple}Checking for the latest Chromedriver${Color_Off}\n"
 if [ -f $CHDB ]; then
-        printf "Current installed Chromedriver: ${Yellow} $CHD_AVB_2D ${Color_Off}\n"
+        printf "Current installed Chromedriver: ${Yellow} $CHD_VER_2D ${Color_Off}\n"
         printf "Current installed Google Chrome: ${Green} $GOOGL_VER_2D ${Color_Off}\n"
         upgrade_cd
 else

--- a/jitsi-updater.sh
+++ b/jitsi-updater.sh
@@ -23,7 +23,7 @@ support="https://switnet.net/support"
 apt_repo="/etc/apt/sources.list.d"
 LOC_REC="TBD"
 ENABLE_BLESSM="TBD"
-CHD_LST="$(curl -sL https://chromedriver.storage.googleapis.com/LATEST_RELEASE)"
+CHD_LTST="$(curl -sL https://chromedriver.storage.googleapis.com/LATEST_RELEASE)"
 CHDB="$(whereis chromedriver | awk '{print$2}')"
 DOMAIN="$(ls /etc/prosody/conf.d/ | grep -v localhost | awk -F'.cfg' '{print $1}' | awk '!NF || !seen[$0]++')"
 NC_DOMAIN="TBD"
@@ -33,19 +33,20 @@ PREAD_PROXY=$(grep -nr "preread_server_name" $JITSI_MEET_PROXY | cut -d ":" -f1)
 fi
 INT_CONF="/usr/share/jitsi-meet/interface_config.js"
 INT_CONF_ETC="/etc/jitsi/meet/$DOMAIN-interface_config.js"
-jibri_packages="$(grep Package /var/lib/apt/lists/download.jitsi.org_*_Packages |sort -u|awk '{print $2}'|sed 's|jigasi||'|paste -s -d ' ')"
+jibri_packages="$(grep Package /var/lib/apt/lists/download.jitsi.org_*_Packages |sort -u|awk '{print $2}'|sed 's|jigasi||')"
 AVATAR="$(grep -r avatar /etc/nginx/sites-*/ 2>/dev/null)"
 if [ -f $apt_repo/google-chrome.list ]; then
-    google_package=$(grep Package /var/lib/apt/lists/dl.google.com_linux_chrome_deb_dists_stable_main_binary-amd64_Packages | sort -u | cut -d ' ' -f2 | paste -s -d ' ')
+    google_package=$(grep Package /var/lib/apt/lists/dl.google.com_linux_chrome_deb_dists_stable_main_binary-amd64_Packages | sort -u | cut -d ' ' -f2)
 else
     echo "Seems no Google repo installed"
 fi
 if [ -z $CHDB ]; then
 	echo "Seems no chromedriver installed"
 else
-    CHD_AVB=$(chromedriver -v | awk '{print $2}')
+    CHD_AVB=$($CHDB -v | awk '{print $2}')
 fi
 
+# True if $1 is greater than $2
 version_gt() { test "$(printf '%s\n' "$@" | sort -V | head -n 1)" != "$1"; }
 
 check_jibri() {
@@ -67,21 +68,6 @@ restart_services() {
 	systemctl restart prosody
 }
 
-upgrade_cd() {
-if version_gt $CHD_LST $CHD_AVB
-then
-	echo "Upgrading ..."
-	wget https://chromedriver.storage.googleapis.com/$CHD_LST/chromedriver_linux64.zip
-	unzip chromedriver_linux64.zip
-	sudo cp chromedriver $CHDB
-	rm -rf chromedriver chromedriver_linux64.zip
-	chromedriver -v
-else
-	echo "No need to upgrade Chromedriver"
-	printf "Current version: ${Green} $CHD_AVB ${Color_Off}\n"
-fi
-}
-
 update_jitsi_repo() {
     apt-get update -o Dir::Etc::sourcelist="sources.list.d/jitsi-$1.list" \
         -o Dir::Etc::sourceparts="-" -o APT::Get::List-Cleanup="0"
@@ -97,12 +83,31 @@ update_google_repo() {
 		echo "No Google repository found"
 	fi
 }
+GOOGL_VER_2D="$(/usr/bin/google-chrome --version|awk '{print$3}'|cut -d "." -f 1,2)"
+upgrade_cd() {
+if [ ! -z $GOOGL_VER_2D ]; then
+    if version_gt $GOOGL_VER_2D "$($CHD_AVB|cut -d "." -f 1,2)"
+    then
+        echo "Upgrading ..."
+        wget https://chromedriver.storage.googleapis.com/$CHD_LTST/chromedriver_linux64.zip
+        unzip chromedriver_linux64.zip
+        sudo cp chromedriver $CHDB
+        rm -rf chromedriver chromedriver_linux64.zip
+        chromedriver -v
+    else
+        echo "No need to upgrade Chromedriver"
+        printf "Current version: ${Green} $CHD_AVB ${Color_Off}\n"
+    fi
+else
+  printf "${Yellow} -> No Google Chrome versión to match, leaving untouched.${Color_Off}\n"
+fi
+}
 
 check_lst_cd() {
 printf "${Purple}Checking for the latest Chromedriver${Color_Off}\n"
 if [ -f $CHDB ]; then
         printf "Current installed Chromedriver: ${Yellow} $CHD_AVB ${Color_Off}\n"
-        printf "Latest Chromedriver version available: ${Green} $CHD_LST ${Color_Off}\n"
+        printf "Latest Chromedriver version available: ${Green} $CHD_LTST ${Color_Off}\n"
         upgrade_cd
 else
 	printf "${Yellow} -> Seems there is no Chromedriver installed${Color_Off}\n"

--- a/jitsi-updater.sh
+++ b/jitsi-updater.sh
@@ -24,6 +24,7 @@ apt_repo="/etc/apt/sources.list.d"
 LOC_REC="TBD"
 ENABLE_BLESSM="TBD"
 CHD_LTST="$(curl -sL https://chromedriver.storage.googleapis.com/LATEST_RELEASE)"
+CHD_LTST_2D="$(echo $CHD_LTST|cut -d "." -f 1,2)"
 CHDB="$(whereis chromedriver | awk '{print$2}')"
 DOMAIN="$(ls /etc/prosody/conf.d/ | grep -v localhost | awk -F'.cfg' '{print $1}' | awk '!NF || !seen[$0]++')"
 NC_DOMAIN="TBD"
@@ -43,7 +44,8 @@ fi
 if [ -z $CHDB ]; then
 	echo "Seems no chromedriver installed"
 else
-    CHD_AVB=$($CHDB -v | awk '{print $2}')
+    CHD_AVB="$($CHDB -v | awk '{print $2}')"
+    CHD_AVB_2D="$(echo $CHD_AVB|cut -d "." -f 1,2)"
 fi
 
 # True if $1 is greater than $2
@@ -86,9 +88,10 @@ update_google_repo() {
 GOOGL_VER_2D="$(/usr/bin/google-chrome --version|awk '{print$3}'|cut -d "." -f 1,2)"
 upgrade_cd() {
 if [ ! -z $GOOGL_VER_2D ]; then
-    if version_gt $GOOGL_VER_2D "$($CHD_AVB|cut -d "." -f 1,2)"
+    if version_gt "$GOOGL_VER_2D" "$CHD_VER_2D" && \
+    [ "$GOOGL_VER_2D" = "$CHD_LTST_2D" ]; then
     then
-        echo "Upgrading ..."
+        echo "Upgrading Chromedriver to Google Chromes version"
         wget https://chromedriver.storage.googleapis.com/$CHD_LTST/chromedriver_linux64.zip
         unzip chromedriver_linux64.zip
         sudo cp chromedriver $CHDB
@@ -96,7 +99,7 @@ if [ ! -z $GOOGL_VER_2D ]; then
         chromedriver -v
     else
         echo "No need to upgrade Chromedriver"
-        printf "Current version: ${Green} $CHD_AVB ${Color_Off}\n"
+        printf "Current version: ${Green} $CHD_AVB_2D ${Color_Off}\n"
     fi
 else
   printf "${Yellow} -> No Google Chrome versión to match, leaving untouched.${Color_Off}\n"
@@ -106,15 +109,15 @@ fi
 check_lst_cd() {
 printf "${Purple}Checking for the latest Chromedriver${Color_Off}\n"
 if [ -f $CHDB ]; then
-        printf "Current installed Chromedriver: ${Yellow} $CHD_AVB ${Color_Off}\n"
-        printf "Latest Chromedriver version available: ${Green} $CHD_LTST ${Color_Off}\n"
+        printf "Current installed Chromedriver: ${Yellow} $CHD_AVB_2D ${Color_Off}\n"
+        printf "Current installed Google Chrome: ${Green} $GOOGL_VER_2D ${Color_Off}\n"
         upgrade_cd
 else
 	printf "${Yellow} -> Seems there is no Chromedriver installed${Color_Off}\n"
 fi
 }
 
-printf "${Blue}Update & upgrade Jitsi and components - v2.3${Color_Off}\n"
+printf "${Blue}Update & upgrade Jitsi and components${Color_Off}\n"
 if [ -f $apt_repo/jitsi-unstable.list ]; then
 	update_jitsi_repo unstable
 	update_google_repo

--- a/jitsi-updater.sh
+++ b/jitsi-updater.sh
@@ -93,11 +93,11 @@ if [ ! -z $GOOGL_VER_2D ]; then
         echo "Upgrading Chromedriver to Google Chromes version"
         wget -q https://chromedriver.storage.googleapis.com/$CHD_LTST/chromedriver_linux64.zip \
              -O /tmp/chromedriver_linux64.zip
-        unzip /tmp/chromedriver_linux64.zip -d /usr/local/bin/
+        unzip -o /tmp/chromedriver_linux64.zip -d /usr/local/bin/
         chown root:root $CHDB
         chmod 0755 $CHDB
         rm -rf /tpm/chromedriver_linux64.zip
-        chromedriver -v
+        printf "Current version: ${Green} $CHD_VER_2D ${Color_Off}\n"
     else
         echo "No need to upgrade Chromedriver"
         printf "Current version: ${Green} $CHD_VER_2D ${Color_Off}\n"

--- a/jitsi-updater.sh
+++ b/jitsi-updater.sh
@@ -97,7 +97,7 @@ if [ ! -z $GOOGL_VER_2D ]; then
         chown root:root $CHDB
         chmod 0755 $CHDB
         rm -rf /tpm/chromedriver_linux64.zip
-        printf "Current version: ${Green} $CHD_VER_2D ${Color_Off}\n"
+        printf "Current version: ${Green} "$($CHDB -v | awk '{print $2}'|cut -d "." -f 1,2)" ${Color_Off}\n"
     else
         echo "No need to upgrade Chromedriver"
         printf "Current version: ${Green} $CHD_VER_2D ${Color_Off}\n"

--- a/jm-bm.sh
+++ b/jm-bm.sh
@@ -53,7 +53,7 @@ sed -i "s|jitsilogo.png|watermark2.png|g" $TITLE_FILE
 sed -i "s|logo-deep-linking.png|watermark2.png|g" $BUNDLE_JS
 sed -i "s|jitsiLogo_square.png|gnome_record.png|g" $BUNDLE_JS
 #Disable logo and url
-if [ -z $(grep -nr ".leftwatermark{display:none" $CSS_FILE) ]; then
+if [ -z "$(grep -nr ".leftwatermark{display:none" "$CSS_FILE")" ]; then
 sed -i "s|.leftwatermark{|.leftwatermark{display:none;|" $CSS_FILE
 fi
 

--- a/quick_jibri_installer.sh
+++ b/quick_jibri_installer.sh
@@ -32,10 +32,11 @@ CR=`echo $'\n> '`
 
 exit_ifinstalled() {
 if [ "$(dpkg-query -W -f='${Status}' $1 2>/dev/null | grep -c "ok installed")" == "1" ]; then
-	echo " This instance already has $1 installed, exiting..."
-	echo " Please try again on a clean system."
-	echo " If you think this is an error, please report to:
-    -> https://github.com/switnet-ltd/quick-jibri-installer/issues"
+	echo "
+This instance already has $1 installed, exiting...
+Please try again on a clean system.
+ If you think this is an error, please report to:
+  -> https://github.com/switnet-ltd/quick-jibri-installer/issues"
 	exit
 fi
 }

--- a/quick_jibri_installer.sh
+++ b/quick_jibri_installer.sh
@@ -379,7 +379,8 @@ if [ -f /usr/local/bin/chromedriver ]; then
 	echo "Chromedriver already installed."
 else
 	echo "Installing Chromedriver"
-	wget -q https://chromedriver.storage.googleapis.com/$CHD_LTST/chromedriver_linux64.zip -O /tmp/chromedriver_linux64.zip
+	wget -q https://chromedriver.storage.googleapis.com/$CHD_LTST/chromedriver_linux64.zip \
+	     -O /tmp/chromedriver_linux64.zip
 	unzip /tmp/chromedriver_linux64.zip -d /usr/local/bin/
 	chown root:root /usr/local/bin/chromedriver
 	chmod 0755 /usr/local/bin/chromedriver

--- a/quick_jibri_installer.sh
+++ b/quick_jibri_installer.sh
@@ -360,7 +360,7 @@ elif [ "$(npm list -g esprima 2>/dev/null | grep -c "esprima")" == "1" ]; then
 	echo "Good. Esprima package is already installed"
 fi
 
-CHD_VER=$(curl -sL https://chromedriver.storage.googleapis.com/LATEST_RELEASE)
+CHD_LTST=$(curl -sL https://chromedriver.storage.googleapis.com/LATEST_RELEASE)
 GCMP_JSON="/etc/opt/chrome/policies/managed/managed_policies.json"
 
 echo "# Installing Google Chrome / ChromeDriver"
@@ -379,7 +379,7 @@ if [ -f /usr/local/bin/chromedriver ]; then
 	echo "Chromedriver already installed."
 else
 	echo "Installing Chromedriver"
-	wget -q https://chromedriver.storage.googleapis.com/$CHD_VER/chromedriver_linux64.zip -O /tmp/chromedriver_linux64.zip
+	wget -q https://chromedriver.storage.googleapis.com/$CHD_LTST/chromedriver_linux64.zip -O /tmp/chromedriver_linux64.zip
 	unzip /tmp/chromedriver_linux64.zip -d /usr/local/bin/
 	chown root:root /usr/local/bin/chromedriver
 	chmod 0755 /usr/local/bin/chromedriver
@@ -758,7 +758,7 @@ sed -i "s|// liveStreamingEnabled: false,|liveStreamingEnabled: true,\\
 #sed -i "$DB_STR,$DB_END{s|// },|},|}" $MEET_CONF
 #fi
 
-#LocalRecording
+#LocalAudioRecording
 if [ "$ENABLE_LAR" = "yes" ]; then
 echo "# Enabling local recording (audio only)."
 LR_STR=$(grep -n "// Local Recording" $MEET_CONF | cut -d ":" -f1)

--- a/quick_jibri_installer.sh
+++ b/quick_jibri_installer.sh
@@ -381,7 +381,7 @@ else
 	echo "Installing Chromedriver"
 	wget -q https://chromedriver.storage.googleapis.com/$CHD_LTST/chromedriver_linux64.zip \
 	     -O /tmp/chromedriver_linux64.zip
-	unzip /tmp/chromedriver_linux64.zip -d /usr/local/bin/
+	unzip -o /tmp/chromedriver_linux64.zip -d /usr/local/bin/
 	chown root:root /usr/local/bin/chromedriver
 	chmod 0755 /usr/local/bin/chromedriver
 	rm -rf /tpm/chromedriver_linux64.zip

--- a/tools/test-jibri-env.sh
+++ b/tools/test-jibri-env.sh
@@ -112,14 +112,14 @@ if [ ! -z "$CHD_VER_LOCAL" ] && [ ! -z "$GOOGL_VER_LOCAL" ]; then
     echo -e "Google Chrome is already up to date: \xE2\x9C\x94"
   else
     echo -e "\nAttempting Google Chrome upgrade!"
-    apt -y install --only-upgrade google-chrome-stable
+    apt -yq install --only-upgrade google-chrome-stable
   fi
 # Only upgrade chromedriver if it's on a lower version, not just a different one.
   if [ $CHD_VER_2D = $GOOGL_VER_2D ]; then
-      echo "Chromedriver version seems acording to Google Chrome"
+      echo -e "\nChromedriver version seems according to Google Chrome: \xE2\x9C\x94"
       T3=1
       elif [ "$(fc_ver $GOOGL_VER_2D $CHD_VER_2D)" = "no" ]; then
-          echo "Updating Chromedriver"
+          echo -e "\nAttempting  Chromedriver update!"
           wget -q https://chromedriver.storage.googleapis.com/$CHD_VER/chromedriver_linux64.zip -O /tmp/chromedriver_linux64.zip
           unzip /tmp/chromedriver_linux64.zip -d /usr/local/bin/
           chown root:root /usr/local/bin/chromedriver

--- a/tools/test-jibri-env.sh
+++ b/tools/test-jibri-env.sh
@@ -32,15 +32,8 @@ fi
 
 echo "Checking for updates...."
 apt-get -q2 update
-apt-get -yq2 install apt-show-versions
-
-JITSI_REPO=$(apt-cache policy | grep http | grep jitsi | grep stable | awk '{print $3}' | head -n 1 | cut -d "/" -f1)
-SND_AL_MODULE=$(lsmod | awk '{print$1}'| grep snd_aloop)
-HWE_VIR_MOD=$(apt-cache madison linux-image-generic-hwe-$(lsb_release -sr) 2>/dev/null|head -n1|grep -c "hwe-$(lsb_release -sr)")
-CONF_JSON="/etc/jitsi/jibri/config.json"
-JIBRI_CONF="/etc/jitsi/jibri/jibri.conf"
-CHD_VER="$(/usr/local/bin/chromedriver --version 2>/dev/null| awk '{print$1,$2}')"
-GOOGL_VER="$(/usr/bin/google-chrome --version 2>/dev/null)"
+apt-get -yq2 install apt-show-versions \
+                     curl
 
 check_google_binaries() {
 if [ -z "$2" ]; then
@@ -49,6 +42,25 @@ else
   echo $2
 fi
 }
+
+vlt() {
+    [ "$1" = "`echo -e "$1\n$2" | sort -V | head -n1`" ]
+}
+
+fc_ver() {
+vlt $1 $2 && echo "yes" || echo "no"
+}
+
+JITSI_REPO=$(apt-cache policy | grep http | grep jitsi | grep stable | awk '{print $3}' | head -n 1 | cut -d "/" -f1)
+SND_AL_MODULE=$(lsmod | awk '{print$1}'| grep snd_aloop)
+HWE_VIR_MOD=$(apt-cache madison linux-image-generic-hwe-$(lsb_release -sr) 2>/dev/null|head -n1|grep -c "hwe-$(lsb_release -sr)")
+CONF_JSON="/etc/jitsi/jibri/config.json"
+JIBRI_CONF="/etc/jitsi/jibri/jibri.conf"
+CHD_VER_LOCAL="$(/usr/local/bin/chromedriver --version 2>/dev/null| awk '{print$1,$2}')"
+GOOGL_VER_LOCAL="$(/usr/bin/google-chrome --version 2>/dev/null)"
+CHD_VER_2D="$(echo $CHD_VER_LOCAL|awk '{print$2}'|cut -d "." -f 1,2)"
+GOOGL_VER_2D="$(echo $GOOGL_VER_LOCAL|awk '{print$3}'|cut -d "." -f 1,2)"
+CHD_VER=$(curl -sL https://chromedriver.storage.googleapis.com/LATEST_RELEASE)
 
 #T1
 echo -e "\n#1 -- Check repository --\n"
@@ -62,7 +74,7 @@ if [ -z $JITSI_REPO ]; then
         exit
       elif [ "$CONT_TEST" = "yes" ]; then
         echo "Hmm, seems there won't be anything to test, continuing anyway..."
-        T=0
+        T1=0
       fi
     done
 else
@@ -89,15 +101,43 @@ fi
 T2=1
 
 #T3
+
 echo -e "\n#3 -- Check Google Chrome/driver software.  --\n"
-check_google_binaries "Chromedriver" "$CHD_VER"
-check_google_binaries "Google Chrome" "$GOOGL_VER"
-if [ ! -z "$CHD_VER" ] && [ ! -z "$GOOGL_VER" ]; then
-T3=1
-elif [ -z "$CHD_VER" ] || [ -z "$GOOGL_VER" ]; then
-T3=0
-else
-T3=0
+check_google_binaries "Google Chrome" "$GOOGL_VER_LOCAL"
+check_google_binaries "Chromedriver" "$CHD_VER_LOCAL"
+
+if [ ! -z "$CHD_VER_LOCAL" ] && [ ! -z "$GOOGL_VER_LOCAL" ]; then
+# Chrome upgrade process
+  if [ "$(apt-show-versions google-chrome-stable | grep -c "uptodate")" = "1" ]; then
+    echo -e "Google Chrome is already up to date: \xE2\x9C\x94"
+  else
+    echo -e "\nAttempting Google Chrome upgrade!"
+    apt -y install --only-upgrade google-chrome-stable
+  fi
+# Only upgrade chromedriver if it's on a lower version, not just a different one.
+  if [ $CHD_VER_2D = $GOOGL_VER_2D ]; then
+      echo "Chromedriver version seems acording to Google Chrome"
+      T3=1
+      elif [ "$(fc_ver $GOOGL_VER_2D $CHD_VER_2D)" = "no" ]; then
+          echo "Updating Chromedriver"
+          wget -q https://chromedriver.storage.googleapis.com/$CHD_VER/chromedriver_linux64.zip -O /tmp/chromedriver_linux64.zip
+          unzip /tmp/chromedriver_linux64.zip -d /usr/local/bin/
+          chown root:root /usr/local/bin/chromedriver
+          chmod 0755 /usr/local/bin/chromedriver
+          rm -rf /tpm/chromedriver_linux64.zip
+          CHD_VER2D_U2D="$(echo $CHD_VER_LOCAL|awk '{print$2}'|cut -d "." -f 1,2)"
+          if [ "$(fc_ver $GOOGL_VER_2D $CHD_VER2D_U2D)" = "yes" ]; then
+              echo "Successfull update"
+              T3=1
+          else
+              echo "Something might gone wrong on the update process, please report."
+              T3=0
+          fi
+      else
+      T3=0
+  fi
+ else
+  T3=0
 fi
 
 #T4

--- a/tools/test-jibri-env.sh
+++ b/tools/test-jibri-env.sh
@@ -123,7 +123,7 @@ if [ ! -z "$CHD_VER_LOCAL" ] && [ ! -z "$GOOGL_VER_LOCAL" ]; then
           chown root:root $CHDB
           chmod 0755 $CHDB
           rm -rf /tpm/chromedriver_linux64.zip
-          if [ "$CHD_VER_2D" = "$GOOGL_VER_2D" ]; then
+          if [ "$($CHDB -v | awk '{print $2}'|cut -d "." -f 1,2)" = "$GOOGL_VER_2D" ]; then
               echo "Successfull update"
               T3=1
           else

--- a/tools/test-jibri-env.sh
+++ b/tools/test-jibri-env.sh
@@ -117,7 +117,8 @@ if [ ! -z "$CHD_VER_LOCAL" ] && [ ! -z "$GOOGL_VER_LOCAL" ]; then
       elif version_gt "$GOOGL_VER_2D" "$CHD_VER_2D" && \
       [ "$GOOGL_VER_2D" = "$CHD_LTST_2D" ]; then
           echo -e "\nAttempting  Chromedriver update!"
-          wget -q https://chromedriver.storage.googleapis.com/$CHD_LTST/chromedriver_linux64.zip -O /tmp/chromedriver_linux64.zip
+          wget -q https://chromedriver.storage.googleapis.com/$CHD_LTST/chromedriver_linux64.zip \
+               -O /tmp/chromedriver_linux64.zip
           unzip /tmp/chromedriver_linux64.zip -d /usr/local/bin/
           chown root:root $CHDB
           chmod 0755 $CHDB

--- a/tools/test-jibri-env.sh
+++ b/tools/test-jibri-env.sh
@@ -56,7 +56,8 @@ CHD_VER_LOCAL="$($CHDB --version 2>/dev/null| awk '{print$1,$2}')"
 GOOGL_VER_LOCAL="$(/usr/bin/google-chrome --version 2>/dev/null)"
 CHD_VER_2D="$(echo $CHD_VER_LOCAL|awk '{print$2}'|cut -d "." -f 1,2)"
 GOOGL_VER_2D="$(echo $GOOGL_VER_LOCAL|awk '{print$3}'|cut -d "." -f 1,2)"
-CHD_LTST=$(curl -sL https://chromedriver.storage.googleapis.com/LATEST_RELEASE)
+CHD_LTST="$(curl -sL https://chromedriver.storage.googleapis.com/LATEST_RELEASE)"
+CHD_LTST_2D="$(echo $CHD_LTST|cut -d "." -f 1,2)"
 
 #T1
 echo -e "\n#1 -- Check repository --\n"
@@ -113,7 +114,8 @@ if [ ! -z "$CHD_VER_LOCAL" ] && [ ! -z "$GOOGL_VER_LOCAL" ]; then
   if [ $CHD_VER_2D = $GOOGL_VER_2D ]; then
       echo -e "\nChromedriver version seems according to Google Chrome: \xE2\x9C\x94"
       T3=1
-      elif version_gt "$GOOGL_VER_2D" "$CHD_VER_2D" ; then
+      elif version_gt "$GOOGL_VER_2D" "$CHD_VER_2D" && \
+      [ "$GOOGL_VER_2D" = "$CHD_LTST_2D" ]; then
           echo -e "\nAttempting  Chromedriver update!"
           wget -q https://chromedriver.storage.googleapis.com/$CHD_LTST/chromedriver_linux64.zip -O /tmp/chromedriver_linux64.zip
           unzip /tmp/chromedriver_linux64.zip -d /usr/local/bin/

--- a/tools/test-jibri-env.sh
+++ b/tools/test-jibri-env.sh
@@ -119,7 +119,7 @@ if [ ! -z "$CHD_VER_LOCAL" ] && [ ! -z "$GOOGL_VER_LOCAL" ]; then
           echo -e "\nAttempting  Chromedriver update!"
           wget -q https://chromedriver.storage.googleapis.com/$CHD_LTST/chromedriver_linux64.zip \
                -O /tmp/chromedriver_linux64.zip
-          unzip /tmp/chromedriver_linux64.zip -d /usr/local/bin/
+          unzip -o /tmp/chromedriver_linux64.zip -d /usr/local/bin/
           chown root:root $CHDB
           chmod 0755 $CHDB
           rm -rf /tpm/chromedriver_linux64.zip


### PR DESCRIPTION
Changes,
- Prevent run installer on system with jitsi already installed.
- Update installer, updater and tester variables related to chrome and chromedriver.
  - Bind google chrome and chromedriver  versions on update process
- Improve jitsi-updater for chromedriver update process
- Add test-jibri-env upgrade capabilities for google chrome and chromedriver
- Some other minor fixes